### PR TITLE
Replace "*" with the real platforms

### DIFF
--- a/library.json
+++ b/library.json
@@ -8,5 +8,16 @@
     "url": "https://github.com/tardate/TextFinder"
   },
   "frameworks": "arduino",
-  "platforms": "*"
+  "platforms": 
+  [
+    "atmelavr",
+  	"atmelsam",
+  	"timsp430",
+  	"titiva",
+  	"teensy",
+  	"freescalekinetis",
+  	"ststm32",
+  	"nordicnrf51",
+  	"nxplpc" 
+  ]
 }


### PR DESCRIPTION
PlatformIO Library Crawler hasn't recognised "*" yet. You can open an issue about it here: https://github.com/platformio/platformio-api